### PR TITLE
Back accounts database by a set of key-value pairs instead of an order-dependant array

### DIFF
--- a/accounts.txt
+++ b/accounts.txt
@@ -1,6 +1,9 @@
-1,user,pass,ADMIN
-2,user2,pass2,MANAGER
-3,charlie,pass,USER
-4,jack,jill.WORKER
-1,cal,carl,USER
-1,gabor,gorbo,ADMIN
+id=1,username=user,password=pass,authlevel=ADMIN
+id=2,username=user2,password=pass2,authlevel=MANAGER
+id=3,username=charlie,password=pass,authlevel=USER
+id=4,username=jack,password=jill,authlevel=WORKER
+id=1,username=cal,password=carl,authlevel=USER
+id=1,username=gabor,password=gorbo,authlevel=ADMIN
+id=1,username=ridoy,password=majorpdorp,authlevel=MANAGER
+password=trump,authlevel=USER,id=1,username=donald
+password=password,authlevel=ADMIN,id=1,username=createdOnRegisterScreen

--- a/src/main/java/agilepuppers/cleanwater/model/AccountDatabase.java
+++ b/src/main/java/agilepuppers/cleanwater/model/AccountDatabase.java
@@ -4,6 +4,9 @@ import agilepuppers.cleanwater.App;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.List;
 
 public class AccountDatabase {
@@ -30,17 +33,36 @@ public class AccountDatabase {
         }
     }
 
-    private static String[][] loadData() {
+    private static List<HashMap<String, String>> loadData() {
         createFile();
         try {
+            //read lines from the .txt
             List<String> lines = Files.readAllLines(databaseFile.toPath());
-            String[][] data = new String[lines.size()][userInfoSize];
-            for (int i = 0; i < lines.size(); ++i) {
-                String[] line = lines.get(i).split(",");
-                for (int j = 0; j < userInfoSize && j < line.length; ++j) {
-                    data[i][j] = line[j];
+            List<HashMap<String, String>> data = new ArrayList<>();
+
+            //parse each line individually
+            for (String line : lines) {
+
+                //each line is a comma-separated-list of key/value pairs
+                String[] columns = line.split(",");
+                HashMap<String, String> dictionary = new HashMap<>();
+
+                for (String keyValuePair : columns) {
+                    if (keyValuePair.contains("=")) {
+                        String[] keyValue = keyValuePair.split("=");
+                        String key = keyValue[0];
+                        String value = keyValue[1];
+
+                        dictionary.put(key, value);
+                    }
                 }
+
+                if (dictionary.size() > 0){
+                    data.add(dictionary);
+                }
+
             }
+
             return data;
         } catch (IOException e) {
             App.current.error(App.FATAL, "Could not load user account data");
@@ -49,7 +71,7 @@ public class AccountDatabase {
     }
 
     public static void addAccount(UserAccount account) {
-        String entry = account.getID() + "," + account.getUsername() + "," + account.getPassword() + "," + account.getAuthorization().toString();
+        String entry = account.serialize();
         try {
             PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(databaseFile.getPath(), true)));
             out.println(entry);
@@ -60,12 +82,17 @@ public class AccountDatabase {
     }
 
     public static UserAccount getUserAccount(String username) {
-        String[][] data = loadData();
-        for (String[] user : data) {
-            if (user.length >= userInfoSize && user[1].equals(username)) {
-                return new UserAccount(Integer.parseInt(user[0]), user[1], user[2], AuthorizationLevel.valueOf(user[3]), new UserProfile());
+        List<HashMap<String, String>> data = loadData();
+        for (HashMap<String, String> userInfo : data) {
+
+            //deserialize into UserAccount object
+            UserAccount account = new UserAccount(userInfo);
+
+            if (account.getUsername() != null && account.getUsername().equals(username)) {
+                return account;
             }
         }
+
         return null;
     }
 

--- a/src/main/java/agilepuppers/cleanwater/model/HashMapConvertible.java
+++ b/src/main/java/agilepuppers/cleanwater/model/HashMapConvertible.java
@@ -1,0 +1,35 @@
+package agilepuppers.cleanwater.model;
+
+import java.util.HashMap;
+
+/**
+ * Created by cal on 9/28/16.
+ */
+public abstract class HashMapConvertible {
+
+    //builds an instance of the object from a HashMap
+    public HashMapConvertible(HashMap<String, String> source) {
+        //override this
+    }
+
+    public HashMapConvertible() { }
+
+    public abstract HashMap<String, String> convertToHashMap();
+
+    //converts the result of convertToHashMap() to a comma-separated list of key-value pairs
+    public String serialize() {
+        StringBuilder builder = new StringBuilder();
+
+        HashMap<String, String> map = this.convertToHashMap();
+        for (String key : map.keySet()) {
+            String value = map.get(key);
+
+            builder.append(key + "=" + value + ",");
+        }
+
+        //create a string and trim the trailing comma
+        String output = builder.toString().substring(0, builder.length() - 1);
+        return output;
+    }
+
+}

--- a/src/main/java/agilepuppers/cleanwater/model/UserAccount.java
+++ b/src/main/java/agilepuppers/cleanwater/model/UserAccount.java
@@ -1,7 +1,16 @@
 package agilepuppers.cleanwater.model;
 
-public class UserAccount {
+import java.util.HashMap;
 
+public class UserAccount extends HashMapConvertible {
+
+    //serialization keys
+    public static final String ID_KEY = "id";
+    public static final String USERNAME_KEY = "username";
+    public static final String PASSWORD_KEY = "password";
+    public static final String AUTHORIZATION_KEY = "authlevel";
+
+    //instance variables
     private final int ID;
     private final String USERNAME;
     private final String PASSWORD;
@@ -37,4 +46,37 @@ public class UserAccount {
         return profile;
     }
 
+
+    //serialization
+
+    public UserAccount(HashMap<String, String> source) {
+        super(source);
+
+        int id = -1;
+
+        try {
+            String idString = source.get(ID_KEY);
+            id = Integer.parseInt(idString);
+        } catch (NumberFormatException e) { }
+
+        this.ID = id;
+        this.USERNAME = source.get(USERNAME_KEY);
+        this.PASSWORD = source.get(PASSWORD_KEY);
+
+        String authString = source.get(AUTHORIZATION_KEY);
+        this.AUTHORIZATION = AuthorizationLevel.valueOf(authString);
+
+        this.profile = null; //no serialization support for Profile yet
+    }
+
+    @Override
+    public HashMap<String, String> convertToHashMap() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put(ID_KEY, "" + ID);
+        map.put(USERNAME_KEY, USERNAME);
+        map.put(PASSWORD_KEY, PASSWORD);
+        map.put(AUTHORIZATION_KEY, AUTHORIZATION.toString());
+
+        return map;
+    }
 }


### PR DESCRIPTION
This builds on the `AccountsDatabase` by making it more robust. 

Order-dependant arrays are fragile and are difficult to maintain once you have a large number of indices. This transitions to order-independant dictionaries (`HashMap`) so that individual properties can be retrieved by a key instead of by an index.

 I also created a new construct `HashMapConvertible` that `UserAccount` implements. This way, the implementation details of serializing and deserializing a User is inside the object itself. Down the road, our `AccountDatabase` can be generalized so that we can persist any object that conforms to  `HashMapConvertible`.